### PR TITLE
[codex] Add Memory Garden vocabulary game

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,13 @@ bubbles/
 - `bun run bundle` - Create `dist/bubbles_v<major>.html`
 - `bun run share` - Bundle and open
 
+## Branch and PR Workflow
+- Do not implement feature work directly on `main`.
+- Before editing files for implementation work, create or switch to a `codex/<description>` feature branch from the current `main`.
+- Keep local `main` clean and aligned with `origin/main`; use it only as the integration base.
+- Open a PR for completed feature work instead of leaving changes uncommitted on `main`.
+- If work accidentally starts on `main`, move the uncommitted changes to a feature branch before committing or opening a PR.
+
 ## Key Design Decisions
 - Keep vanilla HTML/CSS/JS (no frameworks)
 - Canvas for game, DOM for UI overlays (screens, HUD)

--- a/index.html
+++ b/index.html
@@ -34,12 +34,57 @@
                     <span class="game-card-action">בחרו</span>
                 </button>
 
-                <div class="game-choice-card game-choice-card-soon" aria-label="משחק נוסף בקרוב">
-                    <span class="soon-sparkle" aria-hidden="true">✦</span>
-                    <span class="soon-title">עוד משחק</span>
-                    <span class="soon-copy">בקרוב</span>
-                </div>
+                <button type="button" class="game-choice-card game-choice-card-memory" data-game="memory-garden" id="select-memory-btn">
+                    <span class="memory-card-art" aria-hidden="true">
+                        <span class="memory-art-card memory-art-card-he">שמש</span>
+                        <span class="memory-art-card memory-art-card-en">sun</span>
+                        <span class="memory-art-flower memory-flower-1"></span>
+                        <span class="memory-art-flower memory-flower-2"></span>
+                    </span>
+                    <span class="game-card-copy memory-card-copy">
+                        <span class="game-card-name memory-game-name">גן מילים</span>
+                        <span class="game-card-meta">זוגות עברית ואנגלית</span>
+                    </span>
+                    <span class="game-card-action">בחרו</span>
+                </button>
             </div>
+        </div>
+
+        <!-- Memory Garden Screen -->
+        <div id="memory-screen" class="screen">
+            <button id="memory-back-btn" class="back-to-games-btn" type="button" aria-label="חזרה לבחירת משחקים" title="חזרה לבחירת משחקים">
+                <span aria-hidden="true">‹</span>
+                <span>משחקים</span>
+            </button>
+
+            <header class="memory-header">
+                <p class="memory-kicker">משחק זוגות בלי זמן</p>
+                <h1 class="memory-title">גן מילים</h1>
+                <p class="memory-subtitle">מצאו זוגות של עברית ואנגלית</p>
+            </header>
+
+            <div class="memory-controls" aria-label="בחירת קושי">
+                <button type="button" class="memory-difficulty-btn active" data-difficulty="easy">
+                    <span>קל</span>
+                    <small>4 זוגות</small>
+                </button>
+                <button type="button" class="memory-difficulty-btn" data-difficulty="medium">
+                    <span>רגיל</span>
+                    <small>6 זוגות</small>
+                </button>
+                <button type="button" class="memory-difficulty-btn" data-difficulty="hard">
+                    <span>גדול</span>
+                    <small>8 זוגות</small>
+                </button>
+            </div>
+
+            <div class="memory-status-panel" aria-live="polite">
+                <div class="memory-progress" id="memory-progress">0 מתוך 4 זוגות</div>
+                <div class="memory-message" id="memory-message">הפכו שני קלפים שמתחברים</div>
+                <button type="button" id="memory-new-garden-btn" class="memory-new-garden-btn">גן חדש</button>
+            </div>
+
+            <div id="memory-board" class="memory-board" aria-label="קלפי גן מילים"></div>
         </div>
 
         <!-- Start Screen -->

--- a/index.html
+++ b/index.html
@@ -85,6 +85,12 @@
             </div>
 
             <div id="memory-board" class="memory-board" aria-label="קלפי גן מילים"></div>
+
+            <div id="memory-toast" class="memory-toast" role="status" aria-live="polite">
+                <span class="memory-toast-flower" aria-hidden="true"></span>
+                <span id="memory-toast-text" class="memory-toast-text"></span>
+                <span class="memory-toast-spark" aria-hidden="true">✦</span>
+            </div>
         </div>
 
         <!-- Start Screen -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bubbles-game",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bubbles-game",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
         "pixi-filters": "^6.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bubbles-game",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "בועות! - A cooperative bubble-catching game for two players",
   "main": "index.html",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,6 +80,7 @@ let memorySecondCard: HTMLButtonElement | null = null;
 let memoryMatchedPairs = new Set<string>();
 let memoryLocked = false;
 let memoryToastTimer: number | null = null;
+let memoryMismatchTimer: number | null = null;
 
 // Load saved preferences
 function loadPreferences() {
@@ -254,6 +255,8 @@ function setupUI() {
 }
 
 function openBubblesSetup() {
+  clearMemoryMismatchTimer();
+  hideMemoryToast();
   showScreen('start-screen');
 }
 
@@ -264,6 +267,8 @@ function openMemoryGarden() {
 }
 
 function startGame() {
+  clearMemoryMismatchTimer();
+  hideMemoryToast();
   showScreen('game-hud');
 
   gameApp.startGame(
@@ -274,11 +279,15 @@ function startGame() {
 }
 
 function returnToGameSelect() {
+  clearMemoryMismatchTimer();
+  hideMemoryToast();
   gameApp.returnToStart();
   showScreen('game-select-screen');
 }
 
 function returnToStart() {
+  clearMemoryMismatchTimer();
+  hideMemoryToast();
   gameApp.returnToStart();
   showScreen('start-screen');
 }
@@ -330,6 +339,7 @@ function loadHighScores() {
 }
 
 function startMemoryRound(difficulty: MemoryDifficulty) {
+  clearMemoryMismatchTimer();
   memoryDifficulty = difficulty;
   memoryMatchedPairs = new Set<string>();
   memoryFirstCard = null;
@@ -435,7 +445,7 @@ function handleMemoryCardClick(cardButton: HTMLButtonElement) {
     matchMemoryCards();
   } else {
     updateMemoryStatus('כמעט. נסו שוב');
-    window.setTimeout(closeUnmatchedMemoryCards, 850);
+    memoryMismatchTimer = window.setTimeout(closeUnmatchedMemoryCards, 850);
   }
 }
 
@@ -468,8 +478,17 @@ function matchMemoryCards() {
 }
 
 function closeUnmatchedMemoryCards() {
-  const firstCard = memoryFirstCard as HTMLButtonElement;
-  const secondCard = memorySecondCard as HTMLButtonElement;
+  memoryMismatchTimer = null;
+
+  if (!memoryFirstCard || !memorySecondCard || !memoryFirstCard.isConnected || !memorySecondCard.isConnected) {
+    memoryFirstCard = null;
+    memorySecondCard = null;
+    memoryLocked = false;
+    return;
+  }
+
+  const firstCard = memoryFirstCard;
+  const secondCard = memorySecondCard;
 
   firstCard.classList.remove('is-face-up');
   secondCard.classList.remove('is-face-up');
@@ -480,6 +499,13 @@ function closeUnmatchedMemoryCards() {
   memorySecondCard = null;
   memoryLocked = false;
   updateMemoryStatus('הפכו שני קלפים שמתחברים');
+}
+
+function clearMemoryMismatchTimer() {
+  if (memoryMismatchTimer) {
+    clearTimeout(memoryMismatchTimer);
+    memoryMismatchTimer = null;
+  }
 }
 
 function updateMemoryStatus(message: string) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,6 +79,7 @@ let memoryFirstCard: HTMLButtonElement | null = null;
 let memorySecondCard: HTMLButtonElement | null = null;
 let memoryMatchedPairs = new Set<string>();
 let memoryLocked = false;
+let memoryToastTimer: number | null = null;
 
 // Load saved preferences
 function loadPreferences() {
@@ -356,6 +357,7 @@ function startMemoryRound(difficulty: MemoryDifficulty) {
   updateMemoryDifficultyButtons();
   renderMemoryBoard();
   updateMemoryStatus('הפכו שני קלפים שמתחברים');
+  hideMemoryToast();
 }
 
 function shuffleMemoryCards(cards: MemoryCard[]): MemoryCard[] {
@@ -455,14 +457,14 @@ function matchMemoryCards() {
 
   const matchedWord = MEMORY_WORDS.find((word) => word.id === wordId) as MemoryWord;
   const pairCount = MEMORY_DIFFICULTY_PAIRS[memoryDifficulty];
-  const message = memoryMatchedPairs.size === pairCount
-    ? 'הגן מלא מילים!'
-    : `${matchedWord.hebrew} = ${matchedWord.english}`;
+  const isComplete = memoryMatchedPairs.size === pairCount;
+  const message = isComplete ? 'הגן מלא מילים!' : `${matchedWord.hebrew} = ${matchedWord.english}`;
 
   memoryFirstCard = null;
   memorySecondCard = null;
   memoryLocked = false;
   updateMemoryStatus(message);
+  showMemoryToast(matchedWord, isComplete);
 }
 
 function closeUnmatchedMemoryCards() {
@@ -484,6 +486,38 @@ function updateMemoryStatus(message: string) {
   const pairCount = MEMORY_DIFFICULTY_PAIRS[memoryDifficulty];
   requireElement<HTMLDivElement>('memory-progress').textContent = `${memoryMatchedPairs.size} מתוך ${pairCount} זוגות`;
   requireElement<HTMLDivElement>('memory-message').textContent = message;
+}
+
+function showMemoryToast(matchedWord: MemoryWord, isComplete: boolean) {
+  const toast = requireElement<HTMLDivElement>('memory-toast');
+  const toastText = requireElement<HTMLSpanElement>('memory-toast-text');
+  const name = p1Name.trim() || 'לוטם';
+  toastText.textContent = isComplete
+    ? `${name}, גן המילים שלך פורח!`
+    : `${name}, מצאת זוג: ${matchedWord.hebrew} = ${matchedWord.english}`;
+
+  if (memoryToastTimer) {
+    clearTimeout(memoryToastTimer);
+  }
+
+  toast.classList.remove('is-visible', 'is-complete');
+  void toast.offsetWidth;
+  toast.classList.toggle('is-complete', isComplete);
+  toast.classList.add('is-visible');
+
+  memoryToastTimer = window.setTimeout(() => {
+    toast.classList.remove('is-visible', 'is-complete');
+    memoryToastTimer = null;
+  }, isComplete ? 4200 : 3000);
+}
+
+function hideMemoryToast() {
+  if (memoryToastTimer) {
+    clearTimeout(memoryToastTimer);
+    memoryToastTimer = null;
+  }
+
+  document.getElementById('memory-toast')?.classList.remove('is-visible', 'is-complete');
 }
 
 // ==================== WORLD CAROUSEL (Infinite Loop) ====================

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,43 @@ if (versionBadge) {
 // Initialize game
 const gameApp = new GameApp();
 
-type ScreenId = 'game-select-screen' | 'start-screen' | 'game-hud' | 'end-screen';
+type ScreenId = 'game-select-screen' | 'memory-screen' | 'start-screen' | 'game-hud' | 'end-screen';
+type MemoryDifficulty = 'easy' | 'medium' | 'hard';
+type MemoryCardKind = 'hebrew' | 'english';
+
+interface MemoryWord {
+  id: string;
+  hebrew: string;
+  english: string;
+}
+
+interface MemoryCard {
+  cardId: string;
+  wordId: string;
+  kind: MemoryCardKind;
+  text: string;
+}
+
+const MEMORY_WORDS: MemoryWord[] = [
+  { id: 'dog', hebrew: 'כלב', english: 'dog' },
+  { id: 'cat', hebrew: 'חתול', english: 'cat' },
+  { id: 'apple', hebrew: 'תפוח', english: 'apple' },
+  { id: 'banana', hebrew: 'בננה', english: 'banana' },
+  { id: 'sun', hebrew: 'שמש', english: 'sun' },
+  { id: 'moon', hebrew: 'ירח', english: 'moon' },
+  { id: 'house', hebrew: 'בית', english: 'house' },
+  { id: 'car', hebrew: 'מכונית', english: 'car' },
+  { id: 'ball', hebrew: 'כדור', english: 'ball' },
+  { id: 'tree', hebrew: 'עץ', english: 'tree' },
+  { id: 'fish', hebrew: 'דג', english: 'fish' },
+  { id: 'flower', hebrew: 'פרח', english: 'flower' },
+];
+
+const MEMORY_DIFFICULTY_PAIRS: Record<MemoryDifficulty, number> = {
+  easy: 4,
+  medium: 6,
+  hard: 8,
+};
 
 function requireElement<T extends HTMLElement>(id: string): T {
   const element = document.getElementById(id);
@@ -37,6 +73,12 @@ let p1Figure: FigureType = 'blob';
 let p2Figure: FigureType = 'blob';
 let selectedTime = 45;
 let fallingItemsMode: FallingItemMode = 'bubbles';
+let memoryDifficulty: MemoryDifficulty = 'easy';
+let memoryCards: MemoryCard[] = [];
+let memoryFirstCard: HTMLButtonElement | null = null;
+let memorySecondCard: HTMLButtonElement | null = null;
+let memoryMatchedPairs = new Set<string>();
+let memoryLocked = false;
 
 // Load saved preferences
 function loadPreferences() {
@@ -175,8 +217,18 @@ function setupUI() {
 
   // Start button
   requireElement<HTMLButtonElement>('select-bubbles-btn').addEventListener('click', openBubblesSetup);
+  requireElement<HTMLButtonElement>('select-memory-btn').addEventListener('click', openMemoryGarden);
   requireElement<HTMLButtonElement>('back-to-games-btn').addEventListener('click', returnToGameSelect);
   requireElement<HTMLButtonElement>('start-btn').addEventListener('click', startGame);
+  requireElement<HTMLButtonElement>('memory-back-btn').addEventListener('click', returnToGameSelect);
+  requireElement<HTMLButtonElement>('memory-new-garden-btn').addEventListener('click', () => startMemoryRound(memoryDifficulty));
+
+  document.querySelectorAll<HTMLButtonElement>('.memory-difficulty-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const difficulty = btn.dataset.difficulty as MemoryDifficulty;
+      startMemoryRound(difficulty);
+    });
+  });
 
   // Restart button
   document.getElementById('restart-btn')?.addEventListener('click', returnToStart);
@@ -202,6 +254,12 @@ function setupUI() {
 
 function openBubblesSetup() {
   showScreen('start-screen');
+}
+
+function openMemoryGarden() {
+  gameApp.returnToStart();
+  startMemoryRound(memoryDifficulty);
+  showScreen('memory-screen');
 }
 
 function startGame() {
@@ -268,6 +326,164 @@ function loadHighScores() {
       })
       .join('');
   }
+}
+
+function startMemoryRound(difficulty: MemoryDifficulty) {
+  memoryDifficulty = difficulty;
+  memoryMatchedPairs = new Set<string>();
+  memoryFirstCard = null;
+  memorySecondCard = null;
+  memoryLocked = false;
+
+  const pairCount = MEMORY_DIFFICULTY_PAIRS[difficulty];
+  const selectedWords = MEMORY_WORDS.slice(0, pairCount);
+  const cards = selectedWords.flatMap((word): MemoryCard[] => [
+    {
+      cardId: `${word.id}-hebrew`,
+      wordId: word.id,
+      kind: 'hebrew',
+      text: word.hebrew,
+    },
+    {
+      cardId: `${word.id}-english`,
+      wordId: word.id,
+      kind: 'english',
+      text: word.english,
+    },
+  ]);
+
+  memoryCards = shuffleMemoryCards(cards);
+  updateMemoryDifficultyButtons();
+  renderMemoryBoard();
+  updateMemoryStatus('הפכו שני קלפים שמתחברים');
+}
+
+function shuffleMemoryCards(cards: MemoryCard[]): MemoryCard[] {
+  const shuffled = [...cards];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+}
+
+function updateMemoryDifficultyButtons() {
+  document.querySelectorAll<HTMLButtonElement>('.memory-difficulty-btn').forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.difficulty === memoryDifficulty);
+  });
+}
+
+function renderMemoryBoard() {
+  const board = requireElement<HTMLDivElement>('memory-board');
+  board.innerHTML = '';
+  board.dataset.difficulty = memoryDifficulty;
+
+  memoryCards.forEach((card) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `memory-card memory-card-${card.kind}`;
+    button.dataset.cardId = card.cardId;
+    button.dataset.wordId = card.wordId;
+    button.dataset.kind = card.kind;
+    button.setAttribute('aria-label', 'קלף זיכרון סגור');
+
+    const back = document.createElement('span');
+    back.className = 'memory-card-back';
+    back.textContent = '❋';
+
+    const front = document.createElement('span');
+    front.className = 'memory-card-front';
+
+    const word = document.createElement('span');
+    word.className = 'memory-card-word';
+    word.textContent = card.text;
+
+    const language = document.createElement('span');
+    language.className = 'memory-card-language';
+    language.textContent = card.kind === 'hebrew' ? 'עברית' : 'English';
+
+    front.append(word, language);
+    button.append(back, front);
+    button.addEventListener('click', () => handleMemoryCardClick(button));
+    board.append(button);
+  });
+}
+
+function handleMemoryCardClick(cardButton: HTMLButtonElement) {
+  if (memoryLocked || cardButton.classList.contains('is-face-up') || cardButton.classList.contains('is-matched')) {
+    return;
+  }
+
+  revealMemoryCard(cardButton);
+
+  if (!memoryFirstCard) {
+    memoryFirstCard = cardButton;
+    updateMemoryStatus('בחרו את הזוג שלו');
+    return;
+  }
+
+  memorySecondCard = cardButton;
+  memoryLocked = true;
+
+  const isMatch =
+    memoryFirstCard.dataset.wordId === memorySecondCard.dataset.wordId &&
+    memoryFirstCard.dataset.kind !== memorySecondCard.dataset.kind;
+
+  if (isMatch) {
+    matchMemoryCards();
+  } else {
+    updateMemoryStatus('כמעט. נסו שוב');
+    window.setTimeout(closeUnmatchedMemoryCards, 850);
+  }
+}
+
+function revealMemoryCard(cardButton: HTMLButtonElement) {
+  cardButton.classList.add('is-face-up');
+  cardButton.setAttribute('aria-label', cardButton.textContent?.trim() || 'קלף פתוח');
+}
+
+function matchMemoryCards() {
+  const firstCard = memoryFirstCard as HTMLButtonElement;
+  const secondCard = memorySecondCard as HTMLButtonElement;
+  const wordId = firstCard.dataset.wordId as string;
+
+  firstCard.classList.add('is-matched');
+  secondCard.classList.add('is-matched');
+  firstCard.disabled = true;
+  secondCard.disabled = true;
+  memoryMatchedPairs.add(wordId);
+
+  const matchedWord = MEMORY_WORDS.find((word) => word.id === wordId) as MemoryWord;
+  const pairCount = MEMORY_DIFFICULTY_PAIRS[memoryDifficulty];
+  const message = memoryMatchedPairs.size === pairCount
+    ? 'הגן מלא מילים!'
+    : `${matchedWord.hebrew} = ${matchedWord.english}`;
+
+  memoryFirstCard = null;
+  memorySecondCard = null;
+  memoryLocked = false;
+  updateMemoryStatus(message);
+}
+
+function closeUnmatchedMemoryCards() {
+  const firstCard = memoryFirstCard as HTMLButtonElement;
+  const secondCard = memorySecondCard as HTMLButtonElement;
+
+  firstCard.classList.remove('is-face-up');
+  secondCard.classList.remove('is-face-up');
+  firstCard.setAttribute('aria-label', 'קלף זיכרון סגור');
+  secondCard.setAttribute('aria-label', 'קלף זיכרון סגור');
+
+  memoryFirstCard = null;
+  memorySecondCard = null;
+  memoryLocked = false;
+  updateMemoryStatus('הפכו שני קלפים שמתחברים');
+}
+
+function updateMemoryStatus(message: string) {
+  const pairCount = MEMORY_DIFFICULTY_PAIRS[memoryDifficulty];
+  requireElement<HTMLDivElement>('memory-progress').textContent = `${memoryMatchedPairs.size} מתוך ${pairCount} זוגות`;
+  requireElement<HTMLDivElement>('memory-message').textContent = message;
 }
 
 // ==================== WORLD CAROUSEL (Infinite Loop) ====================

--- a/src/styles.css
+++ b/src/styles.css
@@ -745,6 +745,81 @@ canvas {
     font-weight: 900;
 }
 
+.memory-toast {
+    position: fixed;
+    left: 50%;
+    bottom: clamp(22px, 5vh, 54px);
+    z-index: 30;
+    display: grid;
+    grid-template-columns: 48px minmax(170px, auto) 28px;
+    align-items: center;
+    gap: 12px;
+    max-width: min(92vw, 560px);
+    min-height: 68px;
+    padding: 12px 18px 12px 14px;
+    border-radius: 999px;
+    border: 3px solid rgba(255,255,255,0.88);
+    background:
+        radial-gradient(circle at 12% 18%, rgba(255, 230, 109, 0.42), transparent 28%),
+        linear-gradient(180deg, rgba(255,255,255,0.96), rgba(232, 255, 221, 0.96));
+    color: #39768E;
+    font-family: 'Rubik', sans-serif;
+    font-weight: 900;
+    box-shadow:
+        0 10px 0 rgba(90, 158, 58, 0.18),
+        0 22px 44px rgba(57, 118, 142, 0.22),
+        inset 0 3px 0 rgba(255,255,255,0.94);
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, 22px) scale(0.92);
+    transition: opacity 0.22s ease, transform 0.22s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.memory-toast.is-visible {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+}
+
+.memory-toast.is-complete {
+    background:
+        radial-gradient(circle at 12% 18%, rgba(255, 230, 109, 0.5), transparent 30%),
+        linear-gradient(180deg, #FFFFFF 0%, #FFF2A8 44%, #DDF8C5 100%);
+    color: #5A7600;
+    box-shadow:
+        0 10px 0 rgba(212, 168, 0, 0.24),
+        0 24px 52px rgba(90, 158, 58, 0.3),
+        inset 0 3px 0 rgba(255,255,255,0.96);
+}
+
+.memory-toast-flower {
+    position: relative;
+    width: 42px;
+    height: 42px;
+    justify-self: center;
+    border-radius: 50%;
+    background: radial-gradient(circle, #FFE66D 0 23%, #FF9EB5 25% 49%, transparent 51%);
+    box-shadow:
+        0 -22px 0 -10px #FF9EB5,
+        0 22px 0 -10px #FF9EB5,
+        22px 0 0 -10px #FF9EB5,
+        -22px 0 0 -10px #FF9EB5,
+        15px 15px 0 -11px #C9A0DC,
+        -15px -15px 0 -11px #C9A0DC;
+}
+
+.memory-toast-text {
+    font-size: clamp(17px, 3vw, 24px);
+    line-height: 1.2;
+    text-align: center;
+}
+
+.memory-toast-spark {
+    color: #E57A95;
+    font-family: 'Secular One', sans-serif;
+    font-size: 26px;
+    text-shadow: 0 2px 0 rgba(255,255,255,0.85);
+}
+
 /* ==================== START SCREEN ==================== */
 #start-screen {
     /* Transparent background - PIXI canvas provides animated background */
@@ -2059,6 +2134,19 @@ td {
         border-radius: 18px;
     }
 
+    .memory-toast {
+        grid-template-columns: 38px minmax(150px, auto) 22px;
+        gap: 8px;
+        min-height: 58px;
+        padding: 10px 14px 10px 12px;
+        bottom: 18px;
+    }
+
+    .memory-toast-flower {
+        width: 34px;
+        height: 34px;
+    }
+
     .game-choice-card-soon {
         min-height: 150px;
     }
@@ -2208,6 +2296,11 @@ td {
 
     .memory-card {
         min-height: 86px;
+    }
+
+    .memory-toast {
+        max-width: 94vw;
+        border-radius: 28px;
     }
 
     .player-bubble {
@@ -2440,6 +2533,16 @@ td {
 
     .memory-card {
         min-height: 70px;
+    }
+
+    .memory-toast {
+        bottom: 10px;
+        min-height: 50px;
+        padding: 8px 12px;
+    }
+
+    .memory-toast-text {
+        font-size: 15px;
     }
 
     .game-card-bubble-1 {

--- a/src/styles.css
+++ b/src/styles.css
@@ -746,9 +746,7 @@ canvas {
 }
 
 .memory-toast {
-    position: fixed;
-    left: 50%;
-    bottom: clamp(22px, 5vh, 54px);
+    position: relative;
     z-index: 30;
     display: grid;
     grid-template-columns: 48px minmax(170px, auto) 28px;
@@ -771,13 +769,13 @@ canvas {
         inset 0 3px 0 rgba(255,255,255,0.94);
     opacity: 0;
     pointer-events: none;
-    transform: translate(-50%, 22px) scale(0.92);
+    transform: translateY(16px) scale(0.92);
     transition: opacity 0.22s ease, transform 0.22s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
 
 .memory-toast.is-visible {
     opacity: 1;
-    transform: translate(-50%, 0) scale(1);
+    transform: translateY(0) scale(1);
 }
 
 .memory-toast.is-complete {
@@ -2139,7 +2137,6 @@ td {
         gap: 8px;
         min-height: 58px;
         padding: 10px 14px 10px 12px;
-        bottom: 18px;
     }
 
     .memory-toast-flower {
@@ -2536,7 +2533,6 @@ td {
     }
 
     .memory-toast {
-        bottom: 10px;
         min-height: 50px;
         padding: 8px 12px;
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -167,6 +167,17 @@ canvas {
     transition: transform 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease;
 }
 
+.game-choice-card-memory {
+    position: relative;
+    display: grid;
+    grid-template-rows: 1fr auto;
+    gap: 14px;
+    padding: 20px;
+    cursor: pointer;
+    text-align: right;
+    transition: transform 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease;
+}
+
 .game-choice-card-bubbles:hover {
     transform: translateY(-8px) rotate(-1deg);
     border-color: var(--candy-yellow);
@@ -177,7 +188,25 @@ canvas {
         inset 0 3px 0 rgba(255, 255, 255, 0.96);
 }
 
+.game-choice-card-memory:hover {
+    transform: translateY(-8px) rotate(1deg);
+    border-color: #98D9C2;
+    box-shadow:
+        0 25px 0 rgba(72, 140, 102, 0.14),
+        0 38px 70px rgba(61, 134, 164, 0.24),
+        0 0 0 6px rgba(152, 217, 194, 0.32),
+        inset 0 3px 0 rgba(255, 255, 255, 0.96);
+}
+
 .game-choice-card-bubbles:active {
+    transform: translateY(3px) rotate(0);
+    box-shadow:
+        0 10px 0 rgba(86, 144, 151, 0.16),
+        0 20px 42px rgba(61, 134, 164, 0.2),
+        inset 0 3px 0 rgba(255, 255, 255, 0.92);
+}
+
+.game-choice-card-memory:active {
     transform: translateY(3px) rotate(0);
     box-shadow:
         0 10px 0 rgba(86, 144, 151, 0.16),
@@ -235,6 +264,69 @@ canvas {
     bottom: 24px;
 }
 
+.memory-card-art {
+    position: relative;
+    min-height: 166px;
+    border-radius: 24px;
+    display: block;
+    overflow: hidden;
+    background:
+        radial-gradient(circle at 18% 22%, rgba(255, 230, 109, 0.72) 0 13%, transparent 14%),
+        linear-gradient(180deg, #BDEEFF 0%, #EAF9FF 56%, #95D66D 57%, #74BF50 100%);
+}
+
+.memory-art-card {
+    position: absolute;
+    width: 108px;
+    height: 82px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 3px solid rgba(255, 255, 255, 0.78);
+    font-family: 'Secular One', sans-serif;
+    font-size: 25px;
+    color: #39768E;
+    box-shadow: 0 10px 20px rgba(57, 118, 142, 0.18);
+}
+
+.memory-art-card-he {
+    top: 38px;
+    right: 44px;
+    transform: rotate(6deg);
+}
+
+.memory-art-card-en {
+    top: 58px;
+    left: 42px;
+    color: var(--pink-dark);
+    transform: rotate(-8deg);
+}
+
+.memory-art-flower {
+    position: absolute;
+    bottom: 22px;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: radial-gradient(circle, #FFE66D 0 22%, #FF9EB5 24% 48%, transparent 50%);
+    box-shadow:
+        0 -18px 0 -7px #FF9EB5,
+        0 18px 0 -7px #FF9EB5,
+        18px 0 0 -7px #FF9EB5,
+        -18px 0 0 -7px #FF9EB5;
+}
+
+.memory-flower-1 {
+    right: 38px;
+}
+
+.memory-flower-2 {
+    left: 64px;
+    transform: scale(0.78);
+}
+
 .game-card-copy {
     display: flex;
     flex-direction: column;
@@ -256,6 +348,14 @@ canvas {
     font-size: 18px;
     font-weight: 800;
     color: #39768E;
+}
+
+.memory-game-name {
+    color: #4F9F74;
+}
+
+.memory-card-copy {
+    padding-left: 96px;
 }
 
 .game-card-action {
@@ -355,6 +455,294 @@ canvas {
     right: 7%;
     transform: scale(0.78);
     opacity: 0.65;
+}
+
+/* ==================== MEMORY GARDEN ==================== */
+#memory-screen {
+    background:
+        linear-gradient(180deg, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0) 44%),
+        transparent;
+    justify-content: flex-start;
+    gap: clamp(14px, 2.5vh, 24px);
+    padding: 24px clamp(14px, 4vw, 44px) 28px;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.memory-header {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+    margin-top: 4px;
+}
+
+.memory-kicker,
+.memory-subtitle {
+    color: #39768E;
+    background: rgba(255,255,255,0.76);
+    border: 2px solid rgba(255,255,255,0.84);
+    border-radius: 999px;
+    padding: 6px 16px;
+    font-weight: 800;
+    box-shadow: 0 8px 22px rgba(57, 118, 142, 0.12);
+}
+
+.memory-kicker {
+    font-size: clamp(14px, 2vw, 18px);
+}
+
+.memory-subtitle {
+    font-size: clamp(15px, 2.4vw, 20px);
+}
+
+.memory-title {
+    font-family: 'Secular One', sans-serif;
+    font-size: clamp(46px, 9vw, 86px);
+    line-height: 0.95;
+    color: white;
+    text-shadow:
+        0 5px 0 rgba(79, 159, 116, 0.36),
+        0 12px 28px rgba(57, 118, 142, 0.2);
+}
+
+.memory-controls {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.memory-difficulty-btn {
+    min-width: 104px;
+    border: none;
+    border-radius: 22px;
+    padding: 10px 16px;
+    background: rgba(255, 255, 255, 0.82);
+    color: #39768E;
+    font-family: 'Rubik', sans-serif;
+    font-weight: 900;
+    cursor: pointer;
+    box-shadow:
+        0 5px 0 rgba(57, 118, 142, 0.16),
+        0 10px 20px rgba(57, 118, 142, 0.11);
+    transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.memory-difficulty-btn span,
+.memory-difficulty-btn small {
+    display: block;
+}
+
+.memory-difficulty-btn span {
+    font-size: 18px;
+}
+
+.memory-difficulty-btn small {
+    margin-top: 2px;
+    font-size: 12px;
+    color: #6F8D98;
+}
+
+.memory-difficulty-btn:hover {
+    transform: translateY(-3px);
+}
+
+.memory-difficulty-btn.active {
+    background: linear-gradient(180deg, #B8E986 0%, #7EC850 100%);
+    color: white;
+    box-shadow:
+        0 5px 0 #5A9E3A,
+        0 12px 24px rgba(90, 158, 58, 0.22);
+}
+
+.memory-difficulty-btn.active small {
+    color: rgba(255,255,255,0.9);
+}
+
+.memory-status-panel {
+    position: relative;
+    z-index: 2;
+    width: min(94vw, 760px);
+    display: grid;
+    grid-template-columns: minmax(120px, auto) minmax(180px, 1fr) auto;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+    border-radius: 26px;
+    background: rgba(255,255,255,0.78);
+    border: 2px solid rgba(255,255,255,0.82);
+    box-shadow:
+        0 12px 28px rgba(57, 118, 142, 0.13),
+        inset 0 2px 0 rgba(255,255,255,0.88);
+}
+
+.memory-progress,
+.memory-message {
+    font-weight: 900;
+    color: #39768E;
+}
+
+.memory-progress {
+    font-size: clamp(15px, 2vw, 18px);
+    white-space: nowrap;
+}
+
+.memory-message {
+    min-height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    padding: 5px 14px;
+    background: rgba(255, 230, 109, 0.38);
+    font-size: clamp(15px, 2.2vw, 20px);
+}
+
+.memory-new-garden-btn {
+    border: none;
+    border-radius: 999px;
+    padding: 10px 16px;
+    background: linear-gradient(180deg, #FF9EB5 0%, #E57A95 100%);
+    color: white;
+    font-family: 'Rubik', sans-serif;
+    font-size: 16px;
+    font-weight: 900;
+    cursor: pointer;
+    box-shadow: 0 4px 0 rgba(180, 80, 100, 0.55);
+    transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.memory-new-garden-btn:hover {
+    transform: translateY(-3px);
+    box-shadow:
+        0 7px 0 rgba(180, 80, 100, 0.55),
+        0 12px 22px rgba(229, 122, 149, 0.22);
+}
+
+.memory-board {
+    position: relative;
+    z-index: 2;
+    width: min(94vw, 840px);
+    display: grid;
+    grid-template-columns: repeat(4, minmax(88px, 1fr));
+    gap: clamp(10px, 1.8vw, 16px);
+    padding: clamp(12px, 2.2vw, 20px);
+    border-radius: 34px;
+    background:
+        radial-gradient(circle at 18% 20%, rgba(255, 230, 109, 0.26), transparent 28%),
+        linear-gradient(180deg, rgba(255,255,255,0.5), rgba(184,233,134,0.34));
+    border: 2px solid rgba(255,255,255,0.72);
+    box-shadow:
+        0 18px 46px rgba(57, 118, 142, 0.16),
+        inset 0 2px 0 rgba(255,255,255,0.82);
+}
+
+.memory-board[data-difficulty="hard"] {
+    grid-template-columns: repeat(4, minmax(82px, 1fr));
+}
+
+.memory-card {
+    position: relative;
+    min-height: clamp(94px, 13vw, 132px);
+    border: none;
+    border-radius: 22px;
+    cursor: pointer;
+    background: transparent;
+    font-family: 'Rubik', sans-serif;
+    perspective: 800px;
+}
+
+.memory-card-back,
+.memory-card-front {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border-radius: 22px;
+    backface-visibility: hidden;
+    transition: transform 0.32s ease, box-shadow 0.2s ease;
+}
+
+.memory-card-back {
+    background:
+        radial-gradient(circle at 30% 24%, rgba(255,255,255,0.95) 0 11%, transparent 12%),
+        linear-gradient(145deg, #FFB7C8 0%, #98D9C2 100%);
+    color: white;
+    font-family: 'Secular One', sans-serif;
+    font-size: clamp(30px, 5vw, 46px);
+    text-shadow: 0 3px 0 rgba(57, 118, 142, 0.18);
+    box-shadow:
+        0 7px 0 rgba(57, 118, 142, 0.22),
+        0 12px 22px rgba(57, 118, 142, 0.18),
+        inset 0 2px 0 rgba(255,255,255,0.72);
+}
+
+.memory-card-front {
+    transform: rotateY(180deg);
+    background: rgba(255,255,255,0.94);
+    border: 3px solid rgba(255,255,255,0.78);
+    box-shadow:
+        0 7px 0 rgba(57, 118, 142, 0.12),
+        0 12px 22px rgba(57, 118, 142, 0.13),
+        inset 0 2px 0 rgba(255,255,255,0.9);
+}
+
+.memory-card:hover .memory-card-back {
+    transform: translateY(-4px);
+    box-shadow:
+        0 10px 0 rgba(57, 118, 142, 0.2),
+        0 18px 26px rgba(57, 118, 142, 0.2),
+        inset 0 2px 0 rgba(255,255,255,0.72);
+}
+
+.memory-card.is-face-up .memory-card-back,
+.memory-card.is-matched .memory-card-back {
+    transform: rotateY(180deg);
+}
+
+.memory-card.is-face-up .memory-card-front,
+.memory-card.is-matched .memory-card-front {
+    transform: rotateY(0deg);
+}
+
+.memory-card.is-matched .memory-card-front {
+    border-color: #B8E986;
+    background:
+        radial-gradient(circle at 20% 18%, rgba(255, 230, 109, 0.24), transparent 26%),
+        rgba(255,255,255,0.96);
+    box-shadow:
+        0 7px 0 #7EC850,
+        0 14px 26px rgba(90, 158, 58, 0.2),
+        inset 0 2px 0 rgba(255,255,255,0.92);
+}
+
+.memory-card-word {
+    max-width: 100%;
+    padding: 0 8px;
+    color: #2D3436;
+    font-family: 'Secular One', 'Rubik', sans-serif;
+    font-size: clamp(24px, 4vw, 38px);
+    line-height: 1.05;
+    overflow-wrap: anywhere;
+}
+
+.memory-card-english .memory-card-word {
+    color: var(--pink-dark);
+    direction: ltr;
+}
+
+.memory-card-language {
+    margin-top: 8px;
+    color: #6F8D98;
+    font-size: clamp(12px, 1.8vw, 15px);
+    font-weight: 900;
 }
 
 /* ==================== START SCREEN ==================== */
@@ -1596,8 +1984,32 @@ td {
         padding: 16px;
     }
 
+    .game-choice-card-memory {
+        padding: 16px;
+    }
+
     .game-card-art {
         min-height: 132px;
+    }
+
+    .memory-card-art {
+        min-height: 132px;
+    }
+
+    .memory-art-card {
+        width: 92px;
+        height: 68px;
+        font-size: 22px;
+    }
+
+    .memory-art-card-he {
+        right: 34px;
+        top: 28px;
+    }
+
+    .memory-art-card-en {
+        left: 34px;
+        top: 44px;
     }
 
     .game-card-action {
@@ -1608,6 +2020,43 @@ td {
 
     .game-card-copy {
         padding-left: 92px;
+    }
+
+    .memory-card-copy {
+        padding-left: 88px;
+    }
+
+    #memory-screen {
+        padding-top: 16px;
+    }
+
+    .memory-status-panel {
+        grid-template-columns: 1fr;
+        width: min(94vw, 440px);
+        gap: 8px;
+    }
+
+    .memory-board {
+        width: min(94vw, 440px);
+        grid-template-columns: repeat(3, minmax(78px, 1fr));
+    }
+
+    .memory-board[data-difficulty="easy"] {
+        grid-template-columns: repeat(2, minmax(104px, 1fr));
+    }
+
+    .memory-board[data-difficulty="hard"] {
+        grid-template-columns: repeat(4, minmax(62px, 1fr));
+    }
+
+    .memory-card {
+        min-height: 92px;
+        border-radius: 18px;
+    }
+
+    .memory-card-back,
+    .memory-card-front {
+        border-radius: 18px;
     }
 
     .game-choice-card-soon {
@@ -1719,6 +2168,10 @@ td {
         min-height: 116px;
     }
 
+    .memory-card-art {
+        min-height: 116px;
+    }
+
     .game-card-meta {
         font-size: 15px;
     }
@@ -1733,6 +2186,28 @@ td {
         right: 10px;
         padding: 8px 12px;
         font-size: 14px;
+    }
+
+    .memory-controls {
+        gap: 7px;
+    }
+
+    .memory-difficulty-btn {
+        min-width: 88px;
+        padding: 9px 10px;
+    }
+
+    .memory-board,
+    .memory-board[data-difficulty="hard"] {
+        grid-template-columns: repeat(3, minmax(72px, 1fr));
+    }
+
+    .memory-board[data-difficulty="easy"] {
+        grid-template-columns: repeat(2, minmax(104px, 1fr));
+    }
+
+    .memory-card {
+        min-height: 86px;
     }
 
     .player-bubble {
@@ -1774,8 +2249,24 @@ td {
         min-height: 116px;
     }
 
+    .memory-card-art {
+        min-height: 116px;
+    }
+
     .game-card-name {
         font-size: clamp(32px, 6vw, 42px);
+    }
+
+    .memory-title {
+        font-size: clamp(38px, 8vw, 64px);
+    }
+
+    .memory-kicker {
+        display: none;
+    }
+
+    .memory-card {
+        min-height: 82px;
     }
 
     .game-choice-card-soon {
@@ -1888,8 +2379,67 @@ td {
         min-height: 86px;
     }
 
+    .memory-card-art {
+        min-height: 86px;
+    }
+
     .game-card-art img {
         max-height: 82px;
+    }
+
+    .memory-art-card {
+        width: 78px;
+        height: 52px;
+        font-size: 18px;
+    }
+
+    .memory-art-card-he {
+        right: 30px;
+        top: 18px;
+    }
+
+    .memory-art-card-en {
+        left: 30px;
+        top: 28px;
+    }
+
+    #memory-screen {
+        gap: 9px;
+        padding-top: 10px;
+        padding-bottom: 14px;
+    }
+
+    .memory-subtitle {
+        display: none;
+    }
+
+    .memory-controls {
+        gap: 7px;
+    }
+
+    .memory-difficulty-btn {
+        min-width: 84px;
+        padding: 7px 10px;
+    }
+
+    .memory-difficulty-btn span {
+        font-size: 15px;
+    }
+
+    .memory-difficulty-btn small {
+        font-size: 10px;
+    }
+
+    .memory-status-panel {
+        padding: 8px 10px;
+    }
+
+    .memory-board {
+        padding: 10px;
+    }
+
+    .memory-card {
+        min-height: 70px;
     }
 
     .game-card-bubble-1 {
@@ -1965,5 +2515,14 @@ td {
     .game-choice-card-soon {
         min-height: 96px;
         padding: 14px;
+    }
+
+    .memory-board,
+    .memory-board[data-difficulty="hard"] {
+        grid-template-columns: repeat(4, minmax(56px, 1fr));
+    }
+
+    .memory-board[data-difficulty="easy"] {
+        grid-template-columns: repeat(4, minmax(56px, 1fr));
     }
 }


### PR DESCRIPTION
## Summary
- Add Memory Garden as a second selectable game on the landing screen
- Implement a no-timer Hebrew-English memory pairs game
- Add difficulty levels that control pair count: 4, 6, or 8 pairs
- Add progress feedback, a new-garden reset, and back-to-games navigation
- Document the required branch/PR workflow in AGENTS.md
- Bump the app version to 7.2.0

## Validation
- npm run build
- git diff --check
- Computer Use with Arc Browser: opened Memory Garden, switched difficulties, matched a Hebrew-English pair, and returned to the game picker