### PR TITLE
Remove Memory Garden card language labels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bubbles-game",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bubbles-game",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "MIT",
       "dependencies": {
         "pixi-filters": "^6.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bubbles-game",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "בועות! - A cooperative bubble-catching game for two players",
   "main": "index.html",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -410,11 +410,7 @@ function renderMemoryBoard() {
     word.className = 'memory-card-word';
     word.textContent = card.text;
 
-    const language = document.createElement('span');
-    language.className = 'memory-card-language';
-    language.textContent = card.kind === 'hebrew' ? 'עברית' : 'English';
-
-    front.append(word, language);
+    front.append(word);
     button.append(back, front);
     button.addEventListener('click', () => handleMemoryCardClick(button));
     board.append(button);

--- a/src/styles.css
+++ b/src/styles.css
@@ -738,13 +738,6 @@ canvas {
     direction: ltr;
 }
 
-.memory-card-language {
-    margin-top: 8px;
-    color: #6F8D98;
-    font-size: clamp(12px, 1.8vw, 15px);
-    font-weight: 900;
-}
-
 .memory-toast {
     position: relative;
     z-index: 30;


### PR DESCRIPTION
## Summary
- remove the Hebrew/English language label text from Memory Garden card faces
- keep only the vocabulary word on each card
- bump version to 7.2.1

## Verification
- npm run build
- git diff --check
- Browser DOM check: flipped Memory Garden cards show only `apple` and `תפוח`, with zero `.memory-card-language` elements