### PR TITLE
Add kid profiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,9 +15,23 @@
             <div class="game-select-decoration game-select-decoration-cloud game-select-cloud-2" aria-hidden="true"></div>
 
             <header class="game-select-header">
-                <p class="game-select-kicker">משחקים של לוטם ותום</p>
+                <p class="game-select-kicker">משחקים של כולם</p>
                 <h1 class="game-select-title">מה משחקים היום?</h1>
             </header>
+
+            <section class="profiles-panel" aria-label="בחירת פרופיל">
+                <div class="profiles-heading">
+                    <span>מי משחק/ת היום?</span>
+                    <strong id="active-profile-name">לוטם</strong>
+                </div>
+                <div id="profile-list" class="profile-list" aria-label="פרופילים"></div>
+                <div class="profile-editor">
+                    <input id="profile-name-input" type="text" maxlength="10" placeholder="שם של ילד/ה">
+                    <button id="add-profile-btn" type="button">הוסיפו</button>
+                    <button id="rename-profile-btn" type="button">שנו שם</button>
+                    <button id="delete-profile-btn" type="button">מחקו</button>
+                </div>
+            </section>
 
             <div class="game-grid" aria-label="בחירת משחק">
                 <button type="button" class="game-choice-card game-choice-card-bubbles" data-game="bubbles" id="select-bubbles-btn">
@@ -61,6 +75,7 @@
                 <p class="memory-kicker">משחק זוגות בלי זמן</p>
                 <h1 class="memory-title">גן מילים</h1>
                 <p class="memory-subtitle">מצאו זוגות של עברית ואנגלית</p>
+                <p id="memory-profile-badge" class="memory-profile-badge">לוטם משחק/ת</p>
             </header>
 
             <div class="memory-controls" aria-label="בחירת קושי">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bubbles-game",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bubbles-game",
-      "version": "7.3.0",
+      "version": "7.4.0",
       "license": "MIT",
       "dependencies": {
         "pixi-filters": "^6.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bubbles-game",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "בועות! - A cooperative bubble-catching game for two players",
   "main": "index.html",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,12 @@ type ScreenId = 'game-select-screen' | 'memory-screen' | 'start-screen' | 'game-
 type MemoryDifficulty = 'easy' | 'medium' | 'hard';
 type MemoryCardKind = 'hebrew' | 'english';
 
+interface KidProfile {
+  id: string;
+  name: string;
+  emoji: string;
+}
+
 interface MemoryWord {
   id: string;
   hebrew: string;
@@ -53,6 +59,14 @@ const MEMORY_DIFFICULTY_PAIRS: Record<MemoryDifficulty, number> = {
   hard: 8,
 };
 
+const PROFILE_STORAGE_KEY = 'bubble_kid_profiles';
+const ACTIVE_PROFILE_STORAGE_KEY = 'bubble_active_kid_profile';
+const DEFAULT_KID_PROFILES: KidProfile[] = [
+  { id: 'lotem', name: 'לוטם', emoji: '🌸' },
+  { id: 'tom', name: 'תום', emoji: '🫧' },
+];
+const PROFILE_EMOJIS = ['🌸', '🫧', '⭐', '🌈', '🍎', '🦄', '🚗', '☀️', '🐶', '🏠'];
+
 function requireElement<T extends HTMLElement>(id: string): T {
   const element = document.getElementById(id);
   if (!element) {
@@ -68,8 +82,10 @@ function showScreen(screenId: ScreenId) {
 }
 
 // Player state (will be updated by UI)
-let p1Name = localStorage.getItem('bubble_p1_name') || 'לוטם';
-let p2Name = localStorage.getItem('bubble_p2_name') || 'תום';
+let kidProfiles: KidProfile[] = DEFAULT_KID_PROFILES.map((profile) => ({ ...profile }));
+let activeProfileId = DEFAULT_KID_PROFILES[0].id;
+let p1Name = DEFAULT_KID_PROFILES[0].name;
+let p2Name = DEFAULT_KID_PROFILES[1].name;
 let p1Color = 0xff9eb5;
 let p2Color = 0x7ec8e8;
 let p1Figure: FigureType = 'blob';
@@ -96,8 +112,9 @@ function loadPreferences() {
   if (savedFigures.p2) p2Figure = savedFigures.p2;
 
   const savedNames = JSON.parse(localStorage.getItem('bubble_names') || '{}');
-  if (savedNames.p1) p1Name = savedNames.p1;
   if (savedNames.p2) p2Name = savedNames.p2;
+
+  loadProfiles();
 
   const savedTheme = localStorage.getItem('bubble_background_theme');
   if (savedTheme) {
@@ -119,6 +136,18 @@ function loadPreferences() {
 
 // Setup UI event handlers
 function setupUI() {
+  renderProfileList();
+  syncActiveProfileUI();
+
+  requireElement<HTMLButtonElement>('add-profile-btn').addEventListener('click', addProfileFromInput);
+  requireElement<HTMLButtonElement>('rename-profile-btn').addEventListener('click', renameActiveProfileFromInput);
+  requireElement<HTMLButtonElement>('delete-profile-btn').addEventListener('click', deleteActiveProfile);
+  requireElement<HTMLInputElement>('profile-name-input').addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      addProfileFromInput();
+    }
+  });
+
   // Name inputs
   const p1Input = document.getElementById('p1-name') as HTMLInputElement;
   const p2Input = document.getElementById('p2-name') as HTMLInputElement;
@@ -126,7 +155,7 @@ function setupUI() {
   if (p1Input) {
     p1Input.value = p1Name;
     p1Input.addEventListener('input', () => {
-      p1Name = p1Input.value || 'לוטם';
+      renameActiveProfile(p1Input.value);
       localStorage.setItem('bubble_names', JSON.stringify({ p1: p1Name, p2: p2Name }));
     });
   }
@@ -255,6 +284,157 @@ function setupUI() {
       (e.target as HTMLElement).classList.add('hidden');
     }
   });
+}
+
+function loadProfiles() {
+  const savedProfiles = localStorage.getItem(PROFILE_STORAGE_KEY);
+  kidProfiles = savedProfiles ? JSON.parse(savedProfiles) : DEFAULT_KID_PROFILES.map((profile) => ({ ...profile }));
+
+  const savedActiveProfile = localStorage.getItem(ACTIVE_PROFILE_STORAGE_KEY);
+  if (savedActiveProfile) {
+    activeProfileId = savedActiveProfile;
+  }
+
+  if (!kidProfiles.some((profile) => profile.id === activeProfileId)) {
+    activeProfileId = kidProfiles[0].id;
+  }
+
+  p1Name = getActiveProfile().name;
+  saveProfiles();
+}
+
+function getActiveProfile(): KidProfile {
+  const profile = kidProfiles.find((candidate) => candidate.id === activeProfileId);
+  if (!profile) {
+    throw new Error(`Missing active profile ${activeProfileId}`);
+  }
+  return profile;
+}
+
+function saveProfiles() {
+  localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(kidProfiles));
+  localStorage.setItem(ACTIVE_PROFILE_STORAGE_KEY, activeProfileId);
+}
+
+function createProfileId() {
+  return `kid-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+function createProfileEmoji() {
+  return PROFILE_EMOJIS[kidProfiles.length % PROFILE_EMOJIS.length];
+}
+
+function readProfileInput() {
+  return requireElement<HTMLInputElement>('profile-name-input').value.trim();
+}
+
+function addProfileFromInput() {
+  const name = readProfileInput();
+  if (!name) {
+    requireElement<HTMLInputElement>('profile-name-input').focus();
+    return;
+  }
+
+  const profile: KidProfile = {
+    id: createProfileId(),
+    name,
+    emoji: createProfileEmoji(),
+  };
+
+  kidProfiles.push(profile);
+  activeProfileId = profile.id;
+  p1Name = profile.name;
+  saveProfiles();
+  localStorage.setItem('bubble_names', JSON.stringify({ p1: p1Name, p2: p2Name }));
+  requireElement<HTMLInputElement>('profile-name-input').value = '';
+  renderProfileList();
+  syncActiveProfileUI();
+}
+
+function renameActiveProfileFromInput() {
+  renameActiveProfile(readProfileInput());
+  requireElement<HTMLInputElement>('profile-name-input').value = '';
+}
+
+function renameActiveProfile(name: string) {
+  const normalizedName = name.trim() || getActiveProfile().name;
+  const profile = getActiveProfile();
+  profile.name = normalizedName;
+  p1Name = normalizedName;
+  saveProfiles();
+  localStorage.setItem('bubble_names', JSON.stringify({ p1: p1Name, p2: p2Name }));
+  renderProfileList();
+  syncActiveProfileUI();
+}
+
+function deleteActiveProfile() {
+  if (kidProfiles.length === 1) {
+    return;
+  }
+
+  const deletedIndex = kidProfiles.findIndex((profile) => profile.id === activeProfileId);
+  if (deletedIndex === -1) {
+    throw new Error(`Missing active profile ${activeProfileId}`);
+  }
+
+  kidProfiles.splice(deletedIndex, 1);
+  activeProfileId = kidProfiles[Math.max(0, deletedIndex - 1)].id;
+  p1Name = getActiveProfile().name;
+  saveProfiles();
+  localStorage.setItem('bubble_names', JSON.stringify({ p1: p1Name, p2: p2Name }));
+  renderProfileList();
+  syncActiveProfileUI();
+}
+
+function selectProfile(profileId: string) {
+  activeProfileId = profileId;
+  p1Name = getActiveProfile().name;
+  saveProfiles();
+  localStorage.setItem('bubble_names', JSON.stringify({ p1: p1Name, p2: p2Name }));
+  renderProfileList();
+  syncActiveProfileUI();
+}
+
+function renderProfileList() {
+  const list = requireElement<HTMLDivElement>('profile-list');
+  list.innerHTML = '';
+
+  kidProfiles.forEach((profile) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'profile-chip';
+    button.classList.toggle('active', profile.id === activeProfileId);
+    button.setAttribute('aria-pressed', String(profile.id === activeProfileId));
+
+    const avatar = document.createElement('span');
+    avatar.className = 'profile-avatar';
+    avatar.setAttribute('aria-hidden', 'true');
+    avatar.textContent = profile.emoji;
+
+    const name = document.createElement('span');
+    name.className = 'profile-name';
+    name.textContent = profile.name;
+
+    button.append(avatar, name);
+    button.addEventListener('click', () => selectProfile(profile.id));
+    list.append(button);
+  });
+}
+
+function syncActiveProfileUI() {
+  const profile = getActiveProfile();
+  p1Name = profile.name;
+
+  requireElement<HTMLElement>('active-profile-name').textContent = profile.name;
+  requireElement<HTMLElement>('memory-profile-badge').textContent = `${profile.name} משחק/ת`;
+
+  const p1Input = document.getElementById('p1-name') as HTMLInputElement | null;
+  if (p1Input) {
+    p1Input.value = profile.name;
+  }
+
+  const deleteButton = requireElement<HTMLButtonElement>('delete-profile-btn');
+  deleteButton.disabled = kidProfiles.length === 1;
 }
 
 function openBubblesSetup() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -96,9 +96,9 @@ canvas {
     background:
         linear-gradient(180deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 38%),
         transparent;
-    justify-content: center;
-    gap: clamp(24px, 5vh, 44px);
-    padding: clamp(20px, 5vw, 56px);
+    justify-content: flex-start;
+    gap: clamp(16px, 3vh, 30px);
+    padding: clamp(18px, 4vw, 44px);
     overflow-y: auto;
     overflow-x: hidden;
 }
@@ -123,9 +123,168 @@ canvas {
     box-shadow: 0 8px 24px rgba(52, 137, 170, 0.12);
 }
 
+.profiles-panel {
+    position: relative;
+    z-index: 2;
+    width: min(92vw, 780px);
+    display: grid;
+    gap: 12px;
+    padding: 14px;
+    border-radius: 28px;
+    background: rgba(255, 255, 255, 0.78);
+    border: 2px solid rgba(255, 255, 255, 0.84);
+    box-shadow:
+        0 10px 0 rgba(57, 118, 142, 0.11),
+        0 22px 44px rgba(61, 134, 164, 0.17),
+        inset 0 2px 0 rgba(255, 255, 255, 0.92);
+}
+
+.profiles-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    color: #39768E;
+    font-size: clamp(17px, 2.8vw, 22px);
+    font-weight: 900;
+}
+
+.profiles-heading strong {
+    display: inline-flex;
+    align-items: center;
+    min-height: 38px;
+    padding: 6px 16px;
+    border-radius: 999px;
+    background: linear-gradient(180deg, #FFE66D 0%, #FFD36A 100%);
+    color: #8C5B00;
+    box-shadow:
+        0 4px 0 rgba(196, 126, 25, 0.22),
+        inset 0 2px 0 rgba(255,255,255,0.7);
+}
+
+.profile-list {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.profile-chip {
+    min-width: 118px;
+    min-height: 58px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 9px;
+    border: 3px solid rgba(255,255,255,0.86);
+    border-radius: 999px;
+    padding: 8px 16px;
+    background: linear-gradient(180deg, #FFFFFF 0%, #EAF9FF 100%);
+    color: #39768E;
+    font-family: 'Rubik', sans-serif;
+    font-size: 20px;
+    font-weight: 900;
+    cursor: pointer;
+    box-shadow:
+        0 5px 0 rgba(57, 118, 142, 0.15),
+        0 10px 18px rgba(57, 118, 142, 0.12);
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.profile-chip:hover {
+    transform: translateY(-3px);
+    box-shadow:
+        0 8px 0 rgba(57, 118, 142, 0.15),
+        0 14px 22px rgba(57, 118, 142, 0.16);
+}
+
+.profile-chip.active {
+    border-color: #FFE66D;
+    background: linear-gradient(180deg, #FFFAE8 0%, #B8E986 100%);
+    color: #2F7E55;
+    box-shadow:
+        0 5px 0 #7EC850,
+        0 0 0 5px rgba(255, 230, 109, 0.3),
+        0 12px 24px rgba(90, 158, 58, 0.2);
+}
+
+.profile-avatar {
+    width: 34px;
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.72);
+    box-shadow: inset 0 2px 0 rgba(255,255,255,0.84);
+}
+
+.profile-name {
+    line-height: 1;
+}
+
+.profile-editor {
+    display: grid;
+    grid-template-columns: minmax(150px, 1fr) repeat(3, auto);
+    gap: 8px;
+}
+
+.profile-editor input,
+.profile-editor button {
+    min-height: 44px;
+    border: none;
+    border-radius: 999px;
+    font-family: 'Rubik', sans-serif;
+    font-weight: 900;
+}
+
+.profile-editor input {
+    min-width: 0;
+    padding: 8px 16px;
+    background: rgba(255,255,255,0.92);
+    color: var(--text);
+    font-size: 18px;
+    text-align: center;
+    box-shadow:
+        inset 0 2px 6px rgba(57, 118, 142, 0.1),
+        0 3px 0 rgba(57, 118, 142, 0.1);
+}
+
+.profile-editor input:focus {
+    outline: 4px solid rgba(255, 230, 109, 0.48);
+}
+
+.profile-editor button {
+    padding: 8px 14px;
+    background: linear-gradient(180deg, #98D9C2 0%, #4FBE8D 100%);
+    color: white;
+    font-size: 16px;
+    cursor: pointer;
+    box-shadow: 0 4px 0 rgba(47, 126, 85, 0.42);
+    transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.profile-editor button:hover {
+    transform: translateY(-2px);
+    box-shadow:
+        0 6px 0 rgba(47, 126, 85, 0.42),
+        0 10px 18px rgba(47, 126, 85, 0.15);
+}
+
+.profile-editor button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    transform: none;
+}
+
+#delete-profile-btn {
+    background: linear-gradient(180deg, #FFB7C8 0%, #E57A95 100%);
+    box-shadow: 0 4px 0 rgba(180, 80, 100, 0.42);
+}
+
 .game-select-title {
     font-family: 'Secular One', sans-serif;
-    font-size: clamp(48px, 11vw, 118px);
+    font-size: clamp(42px, 8vw, 92px);
     line-height: 0.96;
     color: white;
     text-shadow:
@@ -144,7 +303,7 @@ canvas {
 }
 
 .game-choice-card {
-    min-height: 310px;
+    min-height: clamp(232px, 32vh, 310px);
     border-radius: 34px;
     border: 3px solid rgba(255, 255, 255, 0.82);
     background: rgba(255, 255, 255, 0.82);
@@ -216,7 +375,7 @@ canvas {
 
 .game-card-art {
     position: relative;
-    min-height: 166px;
+    min-height: clamp(112px, 18vh, 166px);
     border-radius: 24px;
     display: flex;
     align-items: center;
@@ -229,7 +388,7 @@ canvas {
 
 .game-card-art img {
     width: min(72%, 245px);
-    max-height: 142px;
+    max-height: clamp(96px, 16vh, 142px);
     object-fit: contain;
     filter: drop-shadow(0 13px 16px rgba(38, 103, 132, 0.18));
     transform: translateY(5px) scale(1.08);
@@ -266,7 +425,7 @@ canvas {
 
 .memory-card-art {
     position: relative;
-    min-height: 166px;
+    min-height: clamp(112px, 18vh, 166px);
     border-radius: 24px;
     display: block;
     overflow: hidden;
@@ -336,7 +495,7 @@ canvas {
 
 .game-card-name {
     font-family: 'Secular One', sans-serif;
-    font-size: clamp(36px, 5vw, 50px);
+    font-size: clamp(34px, 4vw, 50px);
     line-height: 1;
     color: var(--pink-dark);
     text-shadow:
@@ -480,7 +639,8 @@ canvas {
 }
 
 .memory-kicker,
-.memory-subtitle {
+.memory-subtitle,
+.memory-profile-badge {
     color: #39768E;
     background: rgba(255,255,255,0.76);
     border: 2px solid rgba(255,255,255,0.84);
@@ -496,6 +656,12 @@ canvas {
 
 .memory-subtitle {
     font-size: clamp(15px, 2.4vw, 20px);
+}
+
+.memory-profile-badge {
+    font-size: clamp(14px, 2vw, 18px);
+    background: linear-gradient(180deg, rgba(255, 250, 232, 0.92), rgba(232, 255, 221, 0.88));
+    color: #4F9F74;
 }
 
 .memory-title {
@@ -2096,6 +2262,32 @@ td {
         width: min(92vw, 420px);
     }
 
+    .profiles-panel {
+        width: min(92vw, 420px);
+        padding: 12px;
+        border-radius: 24px;
+    }
+
+    .profiles-heading {
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .profile-chip {
+        min-width: 104px;
+        min-height: 52px;
+        font-size: 18px;
+        padding: 7px 13px;
+    }
+
+    .profile-editor {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .profile-editor input {
+        grid-column: 1 / -1;
+    }
+
     .game-choice-card {
         min-height: 236px;
         border-radius: 28px;
@@ -2517,6 +2709,35 @@ td {
 }
 
 /* Very small height */
+@media (max-height: 760px) {
+    #game-select-screen {
+        gap: 12px;
+        padding-top: 12px;
+    }
+
+    .game-select-kicker {
+        padding: 6px 18px;
+    }
+
+    .game-select-title {
+        font-size: clamp(40px, 7vw, 76px);
+    }
+
+    .profiles-panel {
+        gap: 8px;
+        padding: 10px 14px;
+    }
+
+    .profile-chip {
+        min-height: 46px;
+    }
+
+    .profile-editor input,
+    .profile-editor button {
+        min-height: 38px;
+    }
+}
+
 @media (max-height: 550px) {
     .game-grid {
         grid-template-columns: minmax(260px, 380px) minmax(180px, 250px);
@@ -2528,6 +2749,35 @@ td {
 
     .game-choice-card {
         min-height: 172px;
+    }
+
+    .profiles-panel {
+        gap: 8px;
+        padding: 10px;
+    }
+
+    .profiles-heading {
+        font-size: 16px;
+    }
+
+    .profiles-heading strong {
+        min-height: 32px;
+        padding: 4px 12px;
+    }
+
+    .profile-chip {
+        min-height: 44px;
+        font-size: 16px;
+    }
+
+    .profile-avatar {
+        width: 28px;
+        height: 28px;
+    }
+
+    .profile-editor input,
+    .profile-editor button {
+        min-height: 38px;
     }
 
     .game-card-art {


### PR DESCRIPTION
## Summary\n- add a profile picker on the game selection screen with add, rename, delete, and select actions\n- persist profiles and the active child in localStorage\n- sync the selected profile into Bubbles player 1 and Memory Garden copy/toasts\n- bump version to 7.4.0\n\n## Verification\n- npm run build\n- git diff --check\n- agent-browser flow with WebGL flags: reset storage, add profile נועה, open Memory Garden, verify badge is נועה משחק/ת and 8 cards render\n- agent-browser flow: rename active profile to מאיה and verify bubble_names sync, then delete and verify remaining profile selection\n- visual screenshot at 1280x720 after compact layout adjustments