### PR TITLE
Expand Memory Garden vocabulary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bubbles-game",
-  "version": "7.5.4",
+  "version": "7.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bubbles-game",
-      "version": "7.5.4",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
         "pixi-filters": "^6.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bubbles-game",
-  "version": "7.5.4",
+  "version": "7.6.0",
   "description": "בועות! - A cooperative bubble-catching game for two players",
   "main": "index.html",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,6 +85,30 @@ const MEMORY_WORDS: MemoryWord[] = [
   { id: 'tree', hebrew: 'עץ', english: 'tree', drawing: '🌳' },
   { id: 'fish', hebrew: 'דג', english: 'fish', drawing: '🐟' },
   { id: 'flower', hebrew: 'פרח', english: 'flower', drawing: '🌸' },
+  { id: 'door', hebrew: 'דלת', english: 'door', drawing: '🚪' },
+  { id: 'book', hebrew: 'ספר', english: 'book', drawing: '📖' },
+  { id: 'chair', hebrew: 'כיסא', english: 'chair', drawing: '🪑' },
+  { id: 'bed', hebrew: 'מיטה', english: 'bed', drawing: '🛏️' },
+  { id: 'shoe', hebrew: 'נעל', english: 'shoe', drawing: '👟' },
+  { id: 'hat', hebrew: 'כובע', english: 'hat', drawing: '🧢' },
+  { id: 'cup', hebrew: 'כוס', english: 'cup', drawing: '🥤' },
+  { id: 'milk', hebrew: 'חלב', english: 'milk', drawing: '🥛' },
+  { id: 'water', hebrew: 'מים', english: 'water', drawing: '💧' },
+  { id: 'bread', hebrew: 'לחם', english: 'bread', drawing: '🍞' },
+  { id: 'egg', hebrew: 'ביצה', english: 'egg', drawing: '🥚' },
+  { id: 'bird', hebrew: 'ציפור', english: 'bird', drawing: '🐦' },
+  { id: 'cow', hebrew: 'פרה', english: 'cow', drawing: '🐮' },
+  { id: 'duck', hebrew: 'ברווז', english: 'duck', drawing: '🦆' },
+  { id: 'elephant', hebrew: 'פיל', english: 'elephant', drawing: '🐘' },
+  { id: 'baby', hebrew: 'תינוק', english: 'baby', drawing: '👶' },
+  { id: 'hand', hebrew: 'יד', english: 'hand', drawing: '✋' },
+  { id: 'eye', hebrew: 'עין', english: 'eye', drawing: '👁️' },
+  { id: 'nose', hebrew: 'אף', english: 'nose', drawing: '👃' },
+  { id: 'ear', hebrew: 'אוזן', english: 'ear', drawing: '👂' },
+  { id: 'mouth', hebrew: 'פה', english: 'mouth', drawing: '👄' },
+  { id: 'star', hebrew: 'כוכב', english: 'star', drawing: '⭐' },
+  { id: 'rain', hebrew: 'גשם', english: 'rain', drawing: '🌧️' },
+  { id: 'cloud', hebrew: 'ענן', english: 'cloud', drawing: '☁️' },
 ];
 
 const MEMORY_DIFFICULTY_PAIRS: Record<MemoryDifficulty, number> = {
@@ -786,7 +810,7 @@ function startMemoryRound(level: MemoryLevel) {
   memoryLocked = false;
 
   const pairCount = level.pairs;
-  const selectedWords = MEMORY_WORDS.slice(0, pairCount);
+  const selectedWords = selectMemoryWords(pairCount);
   const cards = selectedWords.flatMap((word): MemoryCard[] => [
     {
       cardId: `${word.id}-hebrew`,
@@ -810,6 +834,22 @@ function startMemoryRound(level: MemoryLevel) {
   renderMemoryBoard();
   updateMemoryStatus(`${level.title}: הפכו שני קלפים שמתחברים`);
   hideMemoryToast();
+}
+
+function selectMemoryWords(pairCount: number): MemoryWord[] {
+  if (pairCount > MEMORY_WORDS.length) {
+    throw new Error(`Memory level needs ${pairCount} pairs but only ${MEMORY_WORDS.length} words exist`);
+  }
+  return shuffleMemoryWords(MEMORY_WORDS).slice(0, pairCount);
+}
+
+function shuffleMemoryWords(words: MemoryWord[]): MemoryWord[] {
+  const shuffled = [...words];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
 }
 
 function shuffleMemoryCards(cards: MemoryCard[]): MemoryCard[] {
@@ -844,16 +884,19 @@ function renderMemoryBoard() {
     const front = document.createElement('span');
     front.className = 'memory-card-front';
 
-    const drawing = document.createElement('span');
-    drawing.className = 'memory-card-drawing';
-    drawing.setAttribute('aria-hidden', 'true');
-    drawing.textContent = card.drawing;
-
     const word = document.createElement('span');
     word.className = 'memory-card-word';
     word.textContent = card.text;
 
-    front.append(drawing, word);
+    if (card.kind === 'hebrew') {
+      const drawing = document.createElement('span');
+      drawing.className = 'memory-card-drawing';
+      drawing.setAttribute('aria-hidden', 'true');
+      drawing.textContent = card.drawing;
+      front.append(drawing);
+    }
+
+    front.append(word);
 
     if (card.kind === 'english') {
       const soundButton = document.createElement('button');

--- a/src/main.ts
+++ b/src/main.ts
@@ -984,7 +984,7 @@ function matchMemoryCards() {
   const matchedWord = MEMORY_WORDS.find((word) => word.id === wordId) as MemoryWord;
   const pairCount = activeMemoryLevel.pairs;
   const isComplete = memoryMatchedPairs.size === pairCount;
-  const message = isComplete ? `${activeMemoryLevel.title} הושלם!` : `${matchedWord.hebrew} = ${matchedWord.english}`;
+  const message = isComplete ? `${activeMemoryLevel.title} הושלם!` : `זוג מנצח: ${matchedWord.hebrew} ו-${matchedWord.english}`;
 
   memoryFirstCard = null;
   memorySecondCard = null;
@@ -1327,7 +1327,28 @@ function showMemoryToast(matchedWord: MemoryWord) {
   const toast = requireElement<HTMLDivElement>('memory-toast');
   const toastText = requireElement<HTMLSpanElement>('memory-toast-text');
   const name = p1Name.trim() || 'לוטם';
-  toastText.textContent = `${name}, מצאת זוג: ${matchedWord.hebrew} = ${matchedWord.english}`;
+  const cheer = document.createElement('span');
+  cheer.className = 'memory-toast-cheer';
+  cheer.textContent = `${name}, גילית זוג מילים!`;
+
+  const pair = document.createElement('span');
+  pair.className = 'memory-toast-pair';
+
+  const hebrewWord = document.createElement('span');
+  hebrewWord.className = 'memory-toast-word memory-toast-word-hebrew';
+  hebrewWord.textContent = matchedWord.hebrew;
+
+  const connector = document.createElement('span');
+  connector.className = 'memory-toast-connector';
+  connector.setAttribute('aria-hidden', 'true');
+  connector.textContent = '✨';
+
+  const englishWord = document.createElement('span');
+  englishWord.className = 'memory-toast-word memory-toast-word-english';
+  englishWord.textContent = matchedWord.english;
+
+  pair.append(hebrewWord, connector, englishWord);
+  toastText.replaceChildren(cheer, pair);
 
   if (memoryToastTimer) {
     clearTimeout(memoryToastTimer);

--- a/src/main.ts
+++ b/src/main.ts
@@ -340,8 +340,8 @@ let memoryFirstCard: HTMLDivElement | null = null;
 let memorySecondCard: HTMLDivElement | null = null;
 let memoryMatchedPairs = new Set<string>();
 let memoryLocked = false;
+let memoryNeedsMismatchDismiss = false;
 let memoryToastTimer: number | null = null;
-let memoryMismatchTimer: number | null = null;
 let memoryWinReturnTimer: number | null = null;
 const MEMORY_WIN_RETURN_DELAY_MS = 2400;
 
@@ -678,7 +678,7 @@ function syncActiveProfileUI() {
 }
 
 function openBubblesSetup() {
-  clearMemoryMismatchTimer();
+  clearMemoryMismatchState();
   clearMemoryWinReturnTimer();
   hideMemoryToast();
   hideMemoryCelebration();
@@ -692,7 +692,7 @@ function openMemoryGarden() {
 }
 
 function startGame() {
-  clearMemoryMismatchTimer();
+  clearMemoryMismatchState();
   hideMemoryToast();
   showScreen('game-hud');
 
@@ -704,7 +704,7 @@ function startGame() {
 }
 
 function returnToGameSelect() {
-  clearMemoryMismatchTimer();
+  clearMemoryMismatchState();
   clearMemoryWinReturnTimer();
   hideMemoryToast();
   hideMemoryCelebration();
@@ -713,7 +713,7 @@ function returnToGameSelect() {
 }
 
 function returnToStart() {
-  clearMemoryMismatchTimer();
+  clearMemoryMismatchState();
   clearMemoryWinReturnTimer();
   hideMemoryToast();
   hideMemoryCelebration();
@@ -768,7 +768,7 @@ function loadHighScores() {
 }
 
 function showMemoryLevelMap() {
-  clearMemoryMismatchTimer();
+  clearMemoryMismatchState();
   clearMemoryWinReturnTimer();
   hideMemoryToast();
   hideMemoryCelebration();
@@ -802,12 +802,13 @@ function startMemoryLevel(levelId: MemoryLevelId) {
 }
 
 function startMemoryRound(level: MemoryLevel) {
-  clearMemoryMismatchTimer();
+  clearMemoryMismatchState();
   memoryDifficulty = level.difficulty;
   memoryMatchedPairs = new Set<string>();
   memoryFirstCard = null;
   memorySecondCard = null;
   memoryLocked = false;
+  memoryNeedsMismatchDismiss = false;
 
   const pairCount = level.pairs;
   const selectedWords = selectMemoryWords(pairCount);
@@ -929,6 +930,11 @@ function renderMemoryBoard() {
 }
 
 function handleMemoryCardClick(cardButton: HTMLDivElement) {
+  if (memoryNeedsMismatchDismiss) {
+    closeUnmatchedMemoryCards();
+    return;
+  }
+
   if (memoryLocked || cardButton.classList.contains('is-face-up') || cardButton.classList.contains('is-matched')) {
     return;
   }
@@ -951,8 +957,8 @@ function handleMemoryCardClick(cardButton: HTMLDivElement) {
   if (isMatch) {
     matchMemoryCards();
   } else {
-    updateMemoryStatus('כמעט. נסו שוב');
-    memoryMismatchTimer = window.setTimeout(closeUnmatchedMemoryCards, 850);
+    memoryNeedsMismatchDismiss = true;
+    updateMemoryStatus('לא זוג. לחצו כדי לסגור ולנסות שוב');
   }
 }
 
@@ -998,7 +1004,7 @@ function matchMemoryCards() {
 }
 
 function closeUnmatchedMemoryCards() {
-  memoryMismatchTimer = null;
+  memoryNeedsMismatchDismiss = false;
 
   if (!memoryFirstCard || !memorySecondCard || !memoryFirstCard.isConnected || !memorySecondCard.isConnected) {
     memoryFirstCard = null;
@@ -1023,10 +1029,9 @@ function closeUnmatchedMemoryCards() {
   updateMemoryStatus('הפכו שני קלפים שמתחברים');
 }
 
-function clearMemoryMismatchTimer() {
-  if (memoryMismatchTimer) {
-    clearTimeout(memoryMismatchTimer);
-    memoryMismatchTimer = null;
+function clearMemoryMismatchState() {
+  if (memoryNeedsMismatchDismiss) {
+    closeUnmatchedMemoryCards();
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -985,6 +985,7 @@ function matchMemoryCards() {
   const pairCount = activeMemoryLevel.pairs;
   const isComplete = memoryMatchedPairs.size === pairCount;
   const message = isComplete ? `${activeMemoryLevel.title} הושלם!` : `זוג מנצח: ${matchedWord.hebrew} ו-${matchedWord.english}`;
+  speakMemoryWord(matchedWord.english);
 
   memoryFirstCard = null;
   memorySecondCard = null;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1811,6 +1811,7 @@ canvas {
 .memory-toast.is-visible {
     opacity: 1;
     transform: translateY(0) scale(1);
+    animation: memoryToastPop 0.48s cubic-bezier(0.18, 0.86, 0.24, 1.18) both;
 }
 
 .memory-toast.is-complete {
@@ -1840,10 +1841,67 @@ canvas {
         -15px -15px 0 -11px #C9A0DC;
 }
 
+.memory-toast.is-visible .memory-toast-flower {
+    animation: memoryToastFlowerSpin 0.62s ease both;
+}
+
 .memory-toast-text {
+    display: grid;
+    justify-items: center;
+    gap: 5px;
     font-size: clamp(17px, 3vw, 24px);
     line-height: 1.2;
     text-align: center;
+}
+
+.memory-toast-cheer {
+    color: #39768E;
+    font-size: clamp(15px, 2.3vw, 19px);
+}
+
+.memory-toast-pair {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    direction: ltr;
+    gap: 8px;
+}
+
+.memory-toast-word {
+    min-width: 72px;
+    padding: 5px 12px 6px;
+    border-radius: 999px;
+    background: rgba(255,255,255,0.82);
+    border: 2px solid rgba(255,255,255,0.9);
+    box-shadow:
+        0 4px 0 rgba(57, 118, 142, 0.11),
+        inset 0 2px 0 rgba(255,255,255,0.95);
+    color: #A64B68;
+    font-family: 'Secular One', 'Rubik', sans-serif;
+}
+
+.memory-toast-word-hebrew {
+    direction: rtl;
+}
+
+.memory-toast-word-english {
+    color: #39768E;
+    letter-spacing: 0;
+}
+
+.memory-toast-connector {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    background: linear-gradient(180deg, #FFE66D 0%, #FFB7C8 100%);
+    box-shadow:
+        0 4px 0 rgba(196, 126, 25, 0.18),
+        0 0 16px rgba(255, 230, 109, 0.72),
+        inset 0 2px 0 rgba(255,255,255,0.82);
+    animation: memoryToastSparkle 0.9s ease-in-out infinite alternate;
 }
 
 .memory-toast-spark {
@@ -1851,6 +1909,47 @@ canvas {
     font-family: 'Secular One', sans-serif;
     font-size: 26px;
     text-shadow: 0 2px 0 rgba(255,255,255,0.85);
+}
+
+@keyframes memoryToastPop {
+    0% {
+        transform: translateY(16px) scale(0.86);
+        filter: saturate(0.96);
+    }
+
+    68% {
+        transform: translateY(-4px) scale(1.04);
+        filter: saturate(1.12);
+    }
+
+    100% {
+        transform: translateY(0) scale(1);
+        filter: saturate(1);
+    }
+}
+
+@keyframes memoryToastFlowerSpin {
+    0% {
+        transform: rotate(-24deg) scale(0.65);
+    }
+
+    72% {
+        transform: rotate(14deg) scale(1.14);
+    }
+
+    100% {
+        transform: rotate(0) scale(1);
+    }
+}
+
+@keyframes memoryToastSparkle {
+    from {
+        transform: scale(0.92) rotate(-8deg);
+    }
+
+    to {
+        transform: scale(1.08) rotate(8deg);
+    }
 }
 
 .memory-celebration {


### PR DESCRIPTION
## Summary\n- Expand Memory Garden vocabulary from 12 to 36 words\n- Randomize the selected word subset for every Memory Garden round\n- Remove drawings from English cards while keeping drawings on Hebrew cards\n- Keep mismatched cards face-up until the child clicks to dismiss them\n- Make matched-pair toast more playful with word chips, sparkle connector, and no equals sign\n- Speak the matched English word again on success\n- Slow English speech pronunciation from 0.82 to 0.72\n- Bump version to 7.6.0\n\n## Verification\n- npm run build\n- git diff --check\n- Source acceptance check: 36-word pool, English drawings gated to Hebrew cards, randomized word selection helper present\n- Source acceptance check: mismatches no longer auto-close with a timeout; click-to-dismiss mismatch state is present\n- Source acceptance check: matched-pair toast/status no longer use an equals sign and include structured toast word chips\n- Source acceptance check: successful match calls speakMemoryWord(matchedWord.english)\n- Source acceptance check: speech rate is 0.72\n- Visual proxy screenshot for toast: /tmp/memory-toast-fun-pass.png\n\nNote: In this fresh worktree session, full app browser clicks were unreliable, so I used deterministic source acceptance, production build, and a direct toast DOM visual proxy.